### PR TITLE
update to resilio 2.6.3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ chmod -R +x /etc/service/ /etc/my_init.d/
 ##             INSTALLATION            ##
 #########################################
 
-# Install Resilio 2.6.1
+# Install Resilio 2.6.3
 mkdir -p /opt/resilio
 curl -s -k -L "https://download-cdn.resilio.com/stable/linux-x64/resilio-sync_x64.tar.gz" | tar -xzf - -C /opt/resilio
 


### PR DESCRIPTION
As usual it's just the latest file that it needs to be rebuilt with.
Changelog: https://help.resilio.com/hc/en-us/articles/206216855-Sync-2-x-change-log